### PR TITLE
Add terms of use and unify page layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -138,3 +138,17 @@ a {
 a:hover {
   text-decoration: underline;
 }
+.form-link {
+  display: inline-block;
+  margin-top: 1.25rem;
+  padding: 0.75rem 1.25rem;
+  background-color: #007aff;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 8px;
+  transition: background 0.3s;
+}
+
+.form-link:hover {
+  background-color: #005ecb;
+}

--- a/data-deletion.html
+++ b/data-deletion.html
@@ -5,45 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta name="robots" content="noindex" />
   <title>Request Data Deletion - StyleSync AI</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      background-color: #f5f5f5;
-      margin: 0;
-      padding: 20px;
-    }
-    .container {
-      max-width: 700px;
-      margin: auto;
-      background: #fff;
-      padding: 30px;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-      border-radius: 8px;
-    }
-    h1 {
-      font-size: 24px;
-      color: #2c2c2c;
-    }
-    p {
-      font-size: 16px;
-      color: #444;
-      line-height: 1.6;
-    }
-    .form-link {
-      display: inline-block;
-      margin-top: 20px;
-      padding: 12px 20px;
-      background-color: #007BFF;
-      color: white;
-      text-decoration: none;
-      border-radius: 5px;
-    }
-    .form-link:hover {
-      background-color: #0056b3;
-    }
-  </style>
+<link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
+  <header>
+    <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
+    <h1>StyleSync AI</h1>
+    <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
+    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+  </header>
   <div class="container">
     <h1>Request Data Deletion</h1>
     <p>
@@ -55,7 +25,7 @@
     <a class="form-link" href="https://forms.gle/YOUR_GOOGLE_FORM_ID" target="_blank">
       Submit a Data Deletion Request
     </a>
-    <p style="margin-top: 30px;">
+    <p >
       For additional privacy concerns, feel free to email us at <a href="mailto:stylesyncapp@gmail.com">stylesyncapp@gmail.com</a>.
     </p>
   </div>

--- a/privacy.html
+++ b/privacy.html
@@ -8,6 +8,12 @@
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
+  <header>
+    <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
+    <h1>StyleSync AI</h1>
+    <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
+    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+  </header>
   <div class="container">
     <h1>Privacy Policy</h1>
     <p><strong>Effective Date:</strong> May 15, 2025</p>

--- a/support.html
+++ b/support.html
@@ -8,6 +8,12 @@
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
+  <header>
+    <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
+    <h1>StyleSync AI</h1>
+    <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
+    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+  </header>
   <div class="container">
     <h1>StyleSync AI Support</h1>
     <p>Welcome to the support page for <strong>StyleSync AI</strong>. If you have questions, feedback, or encounter any issues, you can find help below:</p>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Terms of Use - StyleSync AI</title>
+  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+  <header>
+    <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
+    <h1>StyleSync AI</h1>
+    <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
+    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+  </header>
+  <div class="container">
+    <h1>Terms of Use</h1>
+    <p><strong>Effective Date:</strong> May 20, 2025</p>
+
+    <p>These Terms of Use ("Terms") govern your access to and use of the StyleSync AI mobile application (the "App"). By using the App, you agree to comply with these Terms and our Privacy Policy.</p>
+
+    <h2>Use of the App</h2>
+    <p>The App is provided for personal, non-commercial use only. You may not misuse the App or attempt to interfere with its normal operation. All content you submit remains yours, but you grant us permission to process it solely for providing our services.</p>
+
+    <h2>Prohibited Activities</h2>
+    <p>You agree not to engage in any unlawful or harmful conduct while using the App. This includes attempting to reverse engineer the App, transmitting offensive content, or violating any third-party rights.</p>
+
+    <h2>Termination</h2>
+    <p>We may suspend or terminate your access to the App at our discretion if you violate these Terms.</p>
+
+    <h2>Changes</h2>
+    <p>We may update these Terms from time to time. Continued use of the App after changes constitutes acceptance of the updated Terms.</p>
+
+    <h2>Contact Us</h2>
+    <p>If you have questions about these Terms, contact us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
+  </div>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -8,6 +8,12 @@
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
+  <header>
+    <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
+    <h1>StyleSync AI</h1>
+    <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
+    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+  </header>
   <div class="container">
     <h1>Terms of Service</h1>
     <p><strong>Effective Date:</strong> May 20, 2025</p>


### PR DESCRIPTION
## Summary
- add a new **Terms of Use** page
- apply the same header from the index page across support, privacy, terms, and data deletion pages
- move inline styles from the data deletion page into the shared stylesheet
- include a new `.form-link` style in `style.css`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d971fdda4832683011cc8e3f19443