### PR TITLE
Combine terms pages

### DIFF
--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -2,38 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Terms of Use - StyleSync AI</title>
-  <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
-  <link rel="stylesheet" href="assets/css/style.css">
+  <meta http-equiv="refresh" content="0; url=terms.html" />
+  <title>Redirecting...</title>
 </head>
 <body>
-  <header>
-    <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
-    <h1>StyleSync AI</h1>
-    <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
-    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
-  </header>
-  <div class="container">
-    <h1>Terms of Use</h1>
-    <p><strong>Effective Date:</strong> May 20, 2025</p>
-
-    <p>These Terms of Use ("Terms") govern your access to and use of the StyleSync AI mobile application (the "App"). By using the App, you agree to comply with these Terms and our Privacy Policy.</p>
-
-    <h2>Use of the App</h2>
-    <p>The App is provided for personal, non-commercial use only. You may not misuse the App or attempt to interfere with its normal operation. All content you submit remains yours, but you grant us permission to process it solely for providing our services.</p>
-
-    <h2>Prohibited Activities</h2>
-    <p>You agree not to engage in any unlawful or harmful conduct while using the App. This includes attempting to reverse engineer the App, transmitting offensive content, or violating any third-party rights.</p>
-
-    <h2>Termination</h2>
-    <p>We may suspend or terminate your access to the App at our discretion if you violate these Terms.</p>
-
-    <h2>Changes</h2>
-    <p>We may update these Terms from time to time. Continued use of the App after changes constitutes acceptance of the updated Terms.</p>
-
-    <h2>Contact Us</h2>
-    <p>If you have questions about these Terms, contact us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
-  </div>
+  <p>This page has moved to <a href="terms.html">Terms of Service &amp; Use</a>.</p>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Terms of Service - StyleSync AI</title>
+  <title>Terms of Service &amp; Use - StyleSync AI</title>
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
@@ -15,7 +15,7 @@
     <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
   </header>
   <div class="container">
-    <h1>Terms of Service</h1>
+    <h1>Terms of Service &amp; Use</h1>
     <p><strong>Effective Date:</strong> May 20, 2025</p>
 
     <h2>1. Acceptance of Terms</h2>
@@ -61,6 +61,24 @@
     <p>If you have any questions about these Terms, please contact us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
 
     <p>By using the App, you acknowledge that you have read, understood, and agree to be bound by these Terms.</p>
+
+    <h2>Terms of Use</h2>
+    <p>These Terms of Use ("Terms") govern your access to and use of the StyleSync AI mobile application (the "App"). By using the App, you agree to comply with these Terms and our Privacy Policy.</p>
+
+    <h2>Use of the App</h2>
+    <p>The App is provided for personal, non-commercial use only. You may not misuse the App or attempt to interfere with its normal operation. All content you submit remains yours, but you grant us permission to process it solely for providing our services.</p>
+
+    <h2>Prohibited Activities</h2>
+    <p>You agree not to engage in any unlawful or harmful conduct while using the App. This includes attempting to reverse engineer the App, transmitting offensive content, or violating any third-party rights.</p>
+
+    <h2>Termination</h2>
+    <p>We may suspend or terminate your access to the App at our discretion if you violate these Terms.</p>
+
+    <h2>Changes</h2>
+    <p>We may update these Terms from time to time. Continued use of the App after changes constitutes acceptance of the updated Terms.</p>
+
+    <h2>Contact Us</h2>
+    <p>If you have questions about these Terms, contact us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
   
 <h2>Disclosures & Ethical Compliance</h2>
 <p><strong>Amazon Affiliate:</strong> StyleSync AI participates in the Amazon Services LLC Associates Program. We may earn a commission from qualifying purchases made through Amazon links shown in the app. These links are contextual and based solely on outfit-related content you provide.</p>


### PR DESCRIPTION
## Summary
- merge Terms of Service and Terms of Use into single page
- redirect old `terms-of-use.html` to unified page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d98aac96083268eceb16c8c946823