### PR TITLE
Fix headings on Terms page

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -63,33 +63,15 @@
     <h2>14. Contact</h2>
     <p>If you have any questions about these Terms, please contact us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
 
-    <p>By using the App, you acknowledge that you have read, understood, and agree to be bound by these Terms.</p>
-
-    <h2>Terms of Use</h2>
-    <p>These Terms of Use ("Terms") govern your access to and use of the StyleSync AI mobile application (the "App"). By using the App, you agree to comply with these Terms and our Privacy Policy.</p>
-
-    <h2>Use of the App</h2>
-    <p>The App is provided for personal, non-commercial use only. You may not misuse the App or attempt to interfere with its normal operation. All content you submit remains yours, but you grant us permission to process it solely for providing our services.</p>
-
-    <h2>Prohibited Activities</h2>
-    <p>You agree not to engage in any unlawful or harmful conduct while using the App. This includes attempting to reverse engineer the App, transmitting offensive content, or violating any third-party rights.</p>
-
-    <h2>Termination</h2>
-    <p>We may suspend or terminate your access to the App at our discretion if you violate these Terms.</p>
-
-    <h2>Changes</h2>
-    <p>We may update these Terms from time to time. Continued use of the App after changes constitutes acceptance of the updated Terms.</p>
-
-    <h2>Contact Us</h2>
-    <p>If you have questions about these Terms, contact us at <a href="mailto:markmayne@ymail.com">markmayne@ymail.com</a>.</p>
-  
-<h2>Disclosures & Ethical Compliance</h2>
+    <h2>15. Disclosures &amp; Ethical Compliance</h2>
 <p><strong>Amazon Affiliate:</strong> StyleSync AI participates in the Amazon Services LLC Associates Program. We may earn a commission from qualifying purchases made through Amazon links shown in the app. These links are contextual and based solely on outfit-related content you provide.</p>
 
 <p><strong>Google AdMob:</strong> We integrate Google AdMob to display banner, interstitial, and rewarded ads. AdMob may collect and use device data such as IP address, device identifier, and user interaction with ads. Users can opt out of ad personalization through their device settings.</p>
 
-<p><strong>OpenAI API:</strong> StyleSync AI uses OpenAI’s API for AI-powered outfit analysis. Submitted images are sent temporarily for analysis and are not stored or linked to any user identity. This service complies with OpenAI’s data usage policies and ethical AI principles.</p>
+    <p><strong>OpenAI API:</strong> StyleSync AI uses OpenAI’s API for AI-powered outfit analysis. Submitted images are sent temporarily for analysis and are not stored or linked to any user identity. This service complies with OpenAI’s data usage policies and ethical AI principles.</p>
 
-</div>
+    <p>By using the App, you acknowledge that you have read, understood, and agree to be bound by these Terms.</p>
+
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove duplicate sections from terms page
- number the disclosure section as heading 15
- move acknowledgement to end of document

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da04af87c8326b48f88cac18aab3d