### PR TITLE
Detect OS to show correct app store

### DIFF
--- a/assets/js/store-detect.js
+++ b/assets/js/store-detect.js
@@ -1,0 +1,29 @@
+(function() {
+  function getMobileOS() {
+    var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+    if (/android/i.test(userAgent)) {
+      return 'android';
+    }
+    if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+      return 'ios';
+    }
+    return 'other';
+  }
+
+  function updateStoreLinks() {
+    var os = getMobileOS();
+    var appleLink = document.querySelector('.ios-store');
+    var googleLink = document.querySelector('.android-store');
+    if (os === 'android' && appleLink) {
+      appleLink.style.display = 'none';
+    } else if (os === 'ios' && googleLink) {
+      googleLink.style.display = 'none';
+    }
+  }
+
+  if (document.readyState !== 'loading') {
+    updateStoreLinks();
+  } else {
+    document.addEventListener('DOMContentLoaded', updateStoreLinks);
+  }
+})();

--- a/data-deletion.html
+++ b/data-deletion.html
@@ -15,8 +15,8 @@
     <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
     <h1>StyleSync AI</h1>
     <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
-    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
-    <a class="button" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
+    <a class="button ios-store" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+    <a class="button android-store" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
   </header>
   <div class="container">
     <h1>Request Data Deletion</h1>
@@ -33,5 +33,6 @@
       For additional privacy concerns, feel free to email us at <a href="mailto:stylesyncapp@gmail.com">stylesyncapp@gmail.com</a>.
     </p>
   </div>
+  <script src="assets/js/store-detect.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
     <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
     <h1>StyleSync AI</h1>
     <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
-    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
-    <a class="button" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
+    <a class="button ios-store" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+    <a class="button android-store" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
   </header>
 
   <section>
@@ -67,5 +67,6 @@
     <p>© 2025 StyleSync AI</p>
   </footer>
 
+  <script src="assets/js/store-detect.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -15,8 +15,8 @@
     <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
     <h1>StyleSync AI</h1>
     <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
-    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
-    <a class="button" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
+    <a class="button ios-store" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+    <a class="button android-store" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
   </header>
   <div class="container">
     <h1>Privacy Policy</h1>
@@ -67,5 +67,6 @@
 <p><strong>OpenAI API:</strong> StyleSync AI uses OpenAI’s API for AI-powered outfit analysis. Submitted images are sent temporarily for analysis and are not stored or linked to any user identity. This service complies with OpenAI’s data usage policies and ethical AI principles.</p>
 
 </div>
+  <script src="assets/js/store-detect.js"></script>
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -15,8 +15,8 @@
     <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
     <h1>StyleSync AI</h1>
     <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
-    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
-    <a class="button" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
+    <a class="button ios-store" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+    <a class="button android-store" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
   </header>
   <div class="container">
     <h1>StyleSync AI Support</h1>
@@ -50,5 +50,6 @@
 <p><strong>OpenAI API:</strong> StyleSync AI uses OpenAI’s API for AI-powered outfit analysis. Submitted images are sent temporarily for analysis and are not stored or linked to any user identity. This service complies with OpenAI’s data usage policies and ethical AI principles.</p>
 
 </div>
+  <script src="assets/js/store-detect.js"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -15,8 +15,8 @@
     <img src="assets/images/StyleSyncIcon.png" alt="StyleSync AI App Icon" />
     <h1>StyleSync AI</h1>
     <p class="tagline">Your AI-Powered Outfit Matchmaker & Style Coach</p>
-    <a class="button" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
-    <a class="button" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
+    <a class="button ios-store" href="https://apps.apple.com/us/app/stylesync-ai/id6745907418" target="_blank">Download on the App Store</a>
+    <a class="button android-store" href="https://play.google.com/store/apps/details?id=com.markmayne.stylesync" target="_blank">Get it on Google Play</a>
   </header>
   <div class="container">
     <h1>Terms of Service &amp; Use</h1>
@@ -74,5 +74,6 @@
     <p>By using the App, you acknowledge that you have read, understood, and agree to be bound by these Terms.</p>
 
   </div>
+  <script src="assets/js/store-detect.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add JS helper `store-detect.js` to hide the wrong app store link
- add iOS and Android store classes and inject script in each page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685199d5f680832685153d2103827a85